### PR TITLE
Update the readme to specify what the project aims to do

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,40 @@
 # Hare
 
-Hare is a sample MQTT application plus utility modules meant to simplify the use of Tortoise.
+Hare is a sample MQTT application plus utility modules meant to
+simplify the use of Tortoise connecting to a MQTT server on Amazon
+IoT.
+
+Tortoise is a laissez-faire framework for building opinionated MQTT
+clients, and Hare is one of them. Technically the MQTT servers running
+on AWS IoT implement a subset of the MQTT 3.1.1 specification. Notably
+the maximum quality of service allowed on subscriptions and publish
+packages are "at least once delivery" (QoS=1), and retained messages
+are not allowed. A full [list of differences from the MQTT 3.1.1
+protocol is available on the AWS IoT documentation website][mqtt-diff].
+
+[mqtt-diff]: https://docs.aws.amazon.com/iot/latest/developerguide/mqtt.html#mqtt-differences
+
+Hare aims to make an interface that:
+
+- Makes it easy to connect to AWS IoT with the correct encryption
+  enabled
+
+- Makes it impossible (or at least hard) to do things that AWS IoT
+  does not support; such as publishing a message, or subscribing to a
+  topic filter, with a greater quality of service than allowed, or
+  publishing a message with the retain flag set
+
+- Ensure that important messages are delivered to the broker, by
+  having a local "post office" and tracking the in flight messages
+
+Besides this Hare aims to provide helpers for local testing, allowing
+you to test your application without having a connection to AWS; Hare
+should take care of that.
 
 ## MQTT broker
 
-As currently configured, Hare expects an MQTT broker running on localhost via port 1883 with no security.
+As currently configured, for local development, Hare expects an MQTT
+broker running on localhost via port 1883 with no security.
 
 ## Usage
 
@@ -17,8 +47,8 @@ Hare.unsubscribe("racing")
 
 ## Using mosquitto sub and pub
 
-mosquitto_sub -h localhost -p 1883 -t #
-mosquitto_pub -h localhost -p 1883 -t testing -m 123
+`mosquitto_sub -h localhost -p 1883 -t #`
+`mosquitto_pub -h localhost -p 1883 -t testing -m 123`
 
 ## Installation
 


### PR DESCRIPTION
The idea is to turn Hare into an opinionated MQTT client that makes it easy to work with AWS IoT powered by Tortoise.

Tortoise MQTT 5 will be more of an unopinionated framework to build opinionated MQTT clients, so making Hare an example of an opinionated and purpose build client (the purpose is to make it easy to work with AWS IoT, and be rock solid in doing so) will help with the eventual release of the next version of Tortoise. I will have Hare in mind when developing Tortoise.