### PR TITLE
Payload decode error fix and enhancement

### DIFF
--- a/lib/jackalope/handler.ex
+++ b/lib/jackalope/handler.ex
@@ -11,6 +11,7 @@ defmodule Jackalope.Handler do
 
   @type topic :: Tortoise.topic()
   @type topic_filter :: Tortoise.topic_filter()
+  @type topic_levels :: [String.t()]
   @type payload :: term()
 
   @doc """
@@ -48,7 +49,7 @@ defmodule Jackalope.Handler do
   optional `handle_error/1` callback would have been triggered
   instead.
   """
-  @callback handle_message([topic], payload) :: any()
+  @callback handle_message(topic_levels, payload) :: any()
 
   @doc """
   Handle errors produced by Jackalope that should be reacted to
@@ -72,7 +73,7 @@ defmodule Jackalope.Handler do
   """
   @callback handle_error(reason) :: any()
             when reason:
-                   {:payload_decode_error, {topic, payload_string :: String.t()}}
+                   {:payload_decode_error, {topic_levels, payload_string :: String.t()}}
                    | {:publish_error, {topic, payload, opts}, error_reason :: term}
                    | {:publish_error, jackalope_work_order :: term, :ttl_expired},
                  opts: Keyword.t()

--- a/lib/jackalope/handler.ex
+++ b/lib/jackalope/handler.ex
@@ -73,7 +73,8 @@ defmodule Jackalope.Handler do
   """
   @callback handle_error(reason) :: any()
             when reason:
-                   {:payload_decode_error, {topic_levels, payload_string :: String.t()}}
+                   {:payload_decode_error, Jason.DecodeError.t(),
+                    {topic_levels, payload_string :: String.t()}}
                    | {:publish_error, {topic, payload, opts}, error_reason :: term}
                    | {:publish_error, jackalope_work_order :: term, :ttl_expired},
                  opts: Keyword.t()

--- a/lib/jackalope/session.ex
+++ b/lib/jackalope/session.ex
@@ -69,9 +69,9 @@ defmodule Jackalope.Session do
   @doc false
   def publish(topic_and_opts, payload, opts \\ [])
 
-  def publish({topic, publish_opts}, payload, opts) when is_list(topic) do
+  def publish({topic_levels, publish_opts}, payload, opts) when is_list(topic_levels) do
     # normalize the topic list, should be a string
-    topic = Enum.join(topic, "/")
+    topic = Enum.join(topic_levels, "/")
     publish({topic, publish_opts}, payload, opts)
   end
 

--- a/lib/jackalope/tortoise_handler.ex
+++ b/lib/jackalope/tortoise_handler.ex
@@ -44,18 +44,18 @@ defmodule Jackalope.TortoiseHandler do
   end
 
   @impl true
-  def handle_message(topic, payload_string, %State{handler: handler} = state) do
+  def handle_message(topic_levels, payload_string, %State{handler: handler} = state) do
     case Jason.decode(payload_string) do
       {:ok, payload} ->
         # Dispatch to the handle message callback on the jackalope handler
-        apply(handler, :handle_message, [topic, payload])
+        apply(handler, :handle_message, [topic_levels, payload])
         {:ok, state}
 
       {:error, _reason} ->
         # Dispatch to the handle error callback on the jackalope handler if
         # implemented
         if function_exported?(handler, :handle_error, 1) do
-          reason = {:payload_decode_error, {topic, payload_string}}
+          reason = {:payload_decode_error, {topic_levels, payload_string}}
           apply(handler, :handle_error, [reason])
         end
 

--- a/lib/jackalope/tortoise_handler.ex
+++ b/lib/jackalope/tortoise_handler.ex
@@ -51,11 +51,11 @@ defmodule Jackalope.TortoiseHandler do
         apply(handler, :handle_message, [topic_levels, payload])
         {:ok, state}
 
-      {:error, _reason} ->
+      {:error, reason} ->
         # Dispatch to the handle error callback on the jackalope handler if
         # implemented
         if function_exported?(handler, :handle_error, 1) do
-          reason = {:payload_decode_error, {topic_levels, payload_string}}
+          reason = {:payload_decode_error, reason, {topic_levels, payload_string}}
           apply(handler, :handle_error, [reason])
         end
 


### PR DESCRIPTION
* Fix topic return type for :payload_decode_error
  * The `topic` returned in `payload_decode_error` is the same "topic" in `Tortoise.Handler.handle_message/3` which means it is a list of topic levels, but the type for `Jackalope.Handler.handle_message/2` topic is a string.
* Include Jason.DecodeError in :payload_decode_error
  * I think it would be useful to include the Jason.DecodeError in the :payload_decode_error message so that it can be reviewed/reported by the other end if desired.