### PR TITLE
Remove watchdog ping log message

### DIFF
--- a/lib/jackalope/watchdog.ex
+++ b/lib/jackalope/watchdog.ex
@@ -85,7 +85,6 @@ defmodule Jackalope.Watchdog do
   defp ping_tortoise(client_id, timeout) do
     case Tortoise.Connection.ping_sync(client_id, timeout) do
       {:ok, _latency} ->
-        Logger.info("[Jackalope] Watchdog - Connection to MQTT broker is alive")
         :ok
 
       {:error, reason} ->


### PR DESCRIPTION
This message was filling up device logs and it seems like it's no longer
needed.