### PR TITLE
Payloads are no longer JSON-encoded or decoded

### DIFF
--- a/lib/jackalope/handler.ex
+++ b/lib/jackalope/handler.ex
@@ -80,9 +80,7 @@ defmodule Jackalope.Handler do
   """
   @callback handle_error(reason) :: any()
             when reason:
-                   {:payload_decode_error, Jason.DecodeError.t(),
-                    {topic_levels, payload_string :: String.t()}}
-                   | {:publish_error, {topic, payload, opts}, error_reason :: term}
+                   {:publish_error, {topic, payload, opts}, error_reason :: term}
                    | {:publish_error, jackalope_work_order :: term, :ttl_expired},
                  opts: Keyword.t()
 

--- a/lib/jackalope/tortoise_client.ex
+++ b/lib/jackalope/tortoise_client.ex
@@ -45,16 +45,7 @@ defmodule Jackalope.TortoiseClient do
     {client_opts, opts} = Keyword.split(opts, [:timeout])
     timeout = Keyword.get(client_opts, :timeout, 60_000)
 
-    json_payload =
-      case Jason.encode(payload) do
-        {:ok, encoded_payload} ->
-          encoded_payload
-
-        {:error, reason} ->
-          "Unable to encode: #{inspect(payload)} reason: #{inspect(reason)}"
-      end
-
-    GenServer.call(__MODULE__, {:publish, topic, json_payload, opts}, timeout)
+    GenServer.call(__MODULE__, {:publish, topic, payload, opts}, timeout)
   end
 
   def publish(topic, payload, timeout) when is_integer(timeout) and timeout >= 0 do

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,6 @@ defmodule Jackalope.MixProject do
     [
       {:tortoise311, "~> 0.11.0"},
       # {:tortoise311, git: "git@github.com:smartrent/tortoise311.git", branch: "main"},
-      {:jason, "~> 1.1"},
       {:dialyxir, "~> 1.1.0", only: [:test, :dev], runtime: false},
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.22", only: :docs, runtime: false}


### PR DESCRIPTION
Fixes #77
Clients of this library are now responsible for any encoding/decoding.
