### PR TITLE
v0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.7.0
+
+* Updated
+  * BREAKING CHANGE: Jackalope no longer encodes or decodes MQTT message payloads.
+
 ## v0.6.0
 
 * Updates

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Jackalope.MixProject do
   use Mix.Project
 
-  @version "0.6.0"
+  @version "0.7.0"
   @source_url "https://github.com/smartrent/jackalope"
 
   def project() do


### PR DESCRIPTION
Breaking change: MQTT message payloads are no longer encoded/decoded