### PR TITLE
read Jackalope state for crashes

### DIFF
--- a/lib/jackalope.ex
+++ b/lib/jackalope.ex
@@ -194,6 +194,12 @@ defmodule Jackalope do
              ]
   defdelegate publish(topic, payload, opts \\ []), to: Jackalope.Session
 
+  @doc """
+  Get the current MQTT connection status
+  """
+  @spec connection_status() :: :offline | :online
+  defdelegate connection_status(), to: Jackalope.Session
+
   # TODO Get rid of this stuff
   defp connection_options(opts) do
     server =

--- a/lib/jackalope/session.ex
+++ b/lib/jackalope/session.ex
@@ -43,6 +43,13 @@ defmodule Jackalope.Session do
     GenServer.cast(__MODULE__, {:report_connection_status, status})
   end
 
+  @spec connection_status() :: :online | :offline
+  def connection_status() do
+    GenServer.call(__MODULE__, :connection_status)
+  catch
+    _, _ -> :offline
+  end
+
   ## MQTT-ing
   @doc false
   @spec publish(String.t(), any(), keyword) :: :ok | {:error, :invalid_qos | :invalid_ttl}
@@ -90,6 +97,11 @@ defmodule Jackalope.Session do
     }
 
     {:ok, initial_state, {:continue, :consume_work_list}}
+  end
+
+  @impl GenServer
+  def handle_call(:connection_status, _from, state) do
+    {:reply, state.connection_status, state}
   end
 
   @impl GenServer


### PR DESCRIPTION
Adds: 
- `connection_query` function that makes a GenServer call to get the state of `Jackalope.Session`
- GenServer callback that returns the connection_status