### PR TITLE
Pop expired items from the work list

### DIFF
--- a/lib/jackalope/session.ex
+++ b/lib/jackalope/session.ex
@@ -222,6 +222,8 @@ defmodule Jackalope.Session do
             state.handler.handle_error(reason)
           end
 
+          state = %{state | work_list: WorkList.pop(work_list)}
+
           {:noreply, state, {:continue, :consume_work_list}}
         else
           case execute_work(cmd) do


### PR DESCRIPTION
Expired items were not being popped from the work list, leading to an
infinite loop.
